### PR TITLE
Reworked the Application Message to be Built from Decoded Packs

### DIFF
--- a/src/BryptMessage/ApplicationMessage.hpp
+++ b/src/BryptMessage/ApplicationMessage.hpp
@@ -6,7 +6,6 @@
 //------------------------------------------------------------------------------------------------
 #include "MessageContext.hpp"
 #include "MessageHeader.hpp"
-#include "MessageSecurity.hpp"
 #include "MessageTypes.hpp"
 #include "../BryptIdentifier/BryptIdentifier.hpp"
 #include "../Utilities/TimeUtils.hpp"
@@ -54,7 +53,7 @@ public:
 	Command::Type GetCommand() const;
 	std::uint32_t GetPhase() const;
 	Message::Buffer GetData() const;
-	TimeUtils::Timepoint const& GetTimepoint() const;
+	TimeUtils::Timestamp const& GetTimestamp() const;
 	std::optional<Await::TrackerKey> GetAwaitTrackerKey() const;
 
     std::uint32_t GetPackSize() const;
@@ -71,7 +70,7 @@ private:
 	Command::Type m_command; // The application command
 	std::uint8_t m_phase; // The command phase
 	Message::Buffer m_data;	// The command payload
-	TimeUtils::Timepoint m_timepoint; // The message creation timepoint
+	TimeUtils::Timestamp m_timestamp; // The message creation timestamp
 
 	// Optional Extension: Allows the sender to associate to the destination's response with a 
 	// a hopped or flooded request from another peer. 
@@ -103,8 +102,8 @@ public:
 	CApplicationBuilder& BindAwaitTracker(
 		std::optional<Message::BoundTrackerKey> const& optBoundAwaitTracker);
 
-	CApplicationBuilder& FromPack(Message::Buffer const& buffer);
-	CApplicationBuilder& FromPack(std::string_view pack);
+	CApplicationBuilder& FromDecodedPack(Message::Buffer const& buffer);
+	CApplicationBuilder& FromEncodedPack(std::string_view pack);
 
     CApplicationMessage&& Build();
     OptionalMessage ValidatedBuild();

--- a/src/BryptMessage/MessageSecurity.hpp
+++ b/src/BryptMessage/MessageSecurity.hpp
@@ -28,9 +28,7 @@ std::optional<Message::Buffer> Decrypt(
     Message::Buffer const& buffer, std::uint32_t length, std::uint64_t nonce);
 std::optional<Message::Buffer> HMAC(Message::Buffer const& buffer, std::uint32_t length);
 
-VerificationStatus Verify(CApplicationMessage const& message);
 VerificationStatus Verify(Message::Buffer const& buffer);
-VerificationStatus Verify(std::string_view pack);
 	
 //------------------------------------------------------------------------------------------------
 } // MessageSecurity namespace

--- a/src/Utilities/TimeUtils.hpp
+++ b/src/Utilities/TimeUtils.hpp
@@ -13,11 +13,11 @@
 namespace TimeUtils {
 //------------------------------------------------------------------------------------------------
 
-using Timepoint = std::chrono::system_clock::time_point;
 using Timestamp = std::chrono::milliseconds;
+using Timepoint = std::chrono::time_point<std::chrono::system_clock, Timestamp>;
 
 Timepoint GetSystemTimepoint();
-std::string GetSystemTimestamp();
+Timestamp GetSystemTimestamp();
 std::string TimepointToString(Timepoint const& time);
 Timestamp TimepointToTimestamp(Timepoint const& time);
 Timepoint StringToTimepoint(std::string const& timestamp);
@@ -30,20 +30,16 @@ Timepoint StringToTimepoint(std::string const& timestamp);
 
 inline TimeUtils::Timepoint TimeUtils::GetSystemTimepoint()
 {
-    return std::chrono::system_clock::now();
+    return std::chrono::time_point_cast<Timestamp>(std::chrono::system_clock::now());
 }
 
 //------------------------------------------------------------------------------------------------
 
-inline std::string TimeUtils::GetSystemTimestamp()
+inline TimeUtils::Timestamp TimeUtils::GetSystemTimestamp()
 {
-    Timepoint const current = GetSystemTimepoint();
-    auto const milliseconds = std::chrono::duration_cast<Timestamp>(current.time_since_epoch());
-
-    std::stringstream epochStream;
-    epochStream.clear();
-    epochStream << milliseconds.count();
-    return epochStream.str();
+    Timepoint const timepoint = GetSystemTimepoint();
+    auto const milliseconds = std::chrono::duration_cast<Timestamp>(timepoint.time_since_epoch());
+    return milliseconds;
 }
 
 //------------------------------------------------------------------------------------------------
@@ -63,15 +59,6 @@ inline std::string TimeUtils::TimepointToString(Timepoint const& time)
 inline TimeUtils::Timestamp TimeUtils::TimepointToTimestamp(Timepoint const& timepoint)
 {
     return std::chrono::duration_cast<Timestamp>(timepoint.time_since_epoch());
-}
-
-//------------------------------------------------------------------------------------------------
-
-inline TimeUtils::Timepoint TimeUtils::StringToTimepoint(std::string const& timestamp)
-{
-    std::int64_t const llMilliseconds = std::stoll(timestamp);
-    Timestamp const milliseconds(llMilliseconds);
-    return std::chrono::system_clock::time_point(milliseconds);
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
-- Updated message class semantics to allow messages to  be decoded outside of the CApplicationBuilder. The FromPack method was replaced with FromDecodedPack and FromEncodedPack. This change was implemented to allow endpoints to perform the decoding in order to peek the message source without constructing a specific message class. 
-- Updated MessageSecurity to assume the caller has decoded the provided message pack. Removed verification methods where that assumption is less valid. 
-- Updated CApplicationMessage to replace the timepoint member variable with a timestamp member variable. The timestamp is stored in milliseconds. This may enable an outside manager to handle synchronizing clocks with a peer rather than assuming the exact same system_clock time. 
-- Updated TimeUtils to make the Timepoint duration based in milliseconds and removed unused functions.
-- Renamed the MessageTest file to ApplicationMessageTest and updated tests. 